### PR TITLE
Fix see through from above

### DIFF
--- a/ray.py
+++ b/ray.py
@@ -162,7 +162,7 @@ def drawRays2d():
             rx = (py-ry)*Tan+px
             yo = -64
             xo = -yo*Tan
-        elif(radians(ra) < -0.001): # Looking down
+        elif(sin(radians(ra)) < -0.001): # Looking down
             ry = ((int(py) >> 6) << 6) + 64
             rx = (py-ry)*Tan+px
             yo = 64


### PR DESCRIPTION
Using the sin function of the angle in rad ensures that you can't see through north walls from above.